### PR TITLE
Serialize task, edges, etc. in deterministic order (#3682)

### DIFF
--- a/changes/pr3682.yaml
+++ b/changes/pr3682.yaml
@@ -1,0 +1,2 @@
+fix:
+  - "Make `serialized_hash` handle unordered task sets correctly - [#3682](https://github.com/PrefectHQ/prefect/pull/3682)"

--- a/src/prefect/core/flow.py
+++ b/src/prefect/core/flow.py
@@ -1444,6 +1444,7 @@ class Flow:
         flow_copy = self.copy()
         for task, slug in flow_copy.slugs.items():
             task.slug = slug
+
         serialized = schema(exclude=["storage"]).dump(flow_copy)
 
         if build:
@@ -1472,6 +1473,11 @@ class Flow:
         determining if the flow has changed. If this hash is equal to a previous hash,
         no new information would be passed to the server on a call to `flow.register()`
 
+        Note that this will not always detect code changes since the task code is not
+        included in the serialized flow sent to the server. That said, as long as the
+        flow is "built" during registration, the code changes will be in effect even
+        if a new version is not registered with the server.
+
         Args:
             - build (bool, optional):  if `True`, the flow's environment is built
                 prior to serialization. Passed through to `Flow.serialize()`.
@@ -1479,8 +1485,10 @@ class Flow:
         Returns:
             - str: the hash of the serialized flow
         """
+        serialized_flow = self.serialize(build)
+
         return hashlib.sha256(
-            json.dumps(self.serialize(build), sort_keys=True).encode()
+            json.dumps(serialized_flow, sort_keys=True).encode()
         ).hexdigest()
 
     # Diagnostics  ----------------------------------------------------------------

--- a/src/prefect/serialization/environment.py
+++ b/src/prefect/serialization/environment.py
@@ -16,6 +16,7 @@ from prefect.utilities.serialization import (
     OneOfSchema,
     to_qualified_name,
     JSONCompatible,
+    SortedList,
 )
 
 
@@ -23,7 +24,7 @@ class BaseEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = Environment
 
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -31,7 +32,7 @@ class LocalEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = LocalEnvironment
 
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -40,7 +41,7 @@ class DaskKubernetesEnvironmentSchema(ObjectSchema):
         object_class = DaskKubernetesEnvironment
 
     docker_secret = fields.String(allow_none=True)
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
     private_registry = fields.Boolean(allow_none=False)
     min_workers = fields.Int()
@@ -51,7 +52,7 @@ class FargateTaskEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = FargateTaskEnvironment
 
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -59,7 +60,7 @@ class KubernetesJobEnvironmentSchema(ObjectSchema):
     class Meta:
         object_class = KubernetesJobEnvironment
 
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -69,7 +70,7 @@ class RemoteEnvironmentSchema(ObjectSchema):
 
     executor = fields.String(allow_none=True)
     executor_kwargs = fields.Dict(allow_none=True)
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -78,7 +79,7 @@ class RemoteDaskEnvironmentSchema(ObjectSchema):
         object_class = RemoteDaskEnvironment
 
     address = fields.String()
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
 
@@ -87,7 +88,7 @@ class CustomEnvironmentSchema(ObjectSchema):
         object_class = lambda: Environment
         exclude_fields = ["type"]
 
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
     metadata = JSONCompatible(allow_none=True)
 
     type = fields.Function(

--- a/src/prefect/serialization/run_config.py
+++ b/src/prefect/serialization/run_config.py
@@ -1,11 +1,16 @@
 from marshmallow import fields
 
-from prefect.utilities.serialization import JSONCompatible, OneOfSchema, ObjectSchema
+from prefect.utilities.serialization import (
+    JSONCompatible,
+    OneOfSchema,
+    ObjectSchema,
+    SortedList,
+)
 from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
 
 
 class RunConfigSchemaBase(ObjectSchema):
-    labels = fields.List(fields.String())
+    labels = SortedList(fields.String())
 
 
 class KubernetesRunSchema(RunConfigSchemaBase):

--- a/src/prefect/serialization/task.py
+++ b/src/prefect/serialization/task.py
@@ -8,6 +8,7 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     StatefulFunctionReference,
     to_qualified_name,
+    SortedList,
 )
 
 if TYPE_CHECKING:
@@ -71,7 +72,7 @@ class TaskSchema(TaskMethodsMixin, ObjectSchema):
     name = fields.String(allow_none=True)
     slug = fields.String(allow_none=True)
     description = fields.String(allow_none=True)
-    tags = fields.List(fields.String())
+    tags = SortedList(fields.String())
     max_retries = fields.Integer(allow_none=True)
     retry_delay = fields.TimeDelta(allow_none=True)
     inputs = fields.Method("load_inputs", allow_none=True)
@@ -123,5 +124,5 @@ class ParameterSchema(TaskMethodsMixin, ObjectSchema):
     default = JSONCompatible(allow_none=True)
     required = fields.Boolean(allow_none=True)
     description = fields.String(allow_none=True)
-    tags = fields.List(fields.String())
+    tags = SortedList(fields.String())
     outputs = fields.Method("load_outputs", allow_none=True)

--- a/src/prefect/utilities/serialization.py
+++ b/src/prefect/utilities/serialization.py
@@ -231,6 +231,20 @@ class Nested(fields.Nested):
         return super()._serialize(value, attr, obj, **kwargs)
 
 
+class SortedList(fields.List):
+    """
+    An extension of the Marshmallow List field that sorts the serialized object for
+    determinism
+
+    Args:
+        - cls_or_instance (type): the inner field class
+        - **kwargs (Any): the keyword arguments accepted by `marshmallow.Field`
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return sorted(super()._serialize(value, attr, obj, **kwargs))
+
+
 class OneOfSchema(marshmallow_oneofschema.OneOfSchema):
     """
     A subclass of marshmallow_oneofschema.OneOfSchema that excludes unknown fields

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -10,6 +10,7 @@ import time
 import subprocess
 import textwrap
 from unittest.mock import MagicMock, patch
+from random import shuffle
 
 import cloudpickle
 import pendulum
@@ -1899,6 +1900,42 @@ class TestSerializedHash:
 
         assert hashes[0]  # Ensure we don't have an empty string or None
         assert len(set(hashes)) == 1
+
+    def test_task_order_is_deterministic(self):
+        def my_fake_task(foo):
+            pass
+
+        tasks = [task(my_fake_task) for _ in range(5)]
+
+        def make_flow():
+            with Flow("example-flow") as flow:
+                shuffle(tasks)  # Shuffle for a higher likelihood of failure
+                for i, fake_task in enumerate(tasks):
+                    fake_task(tasks[(i + 1) % len(tasks)])
+            return flow
+
+        flows = [make_flow() for _ in range(10)]
+
+        hashes = {flow.serialized_hash() for flow in flows}
+        assert len(hashes) == 1
+
+    def test_parameter_order_is_deterministic(self):
+        @task
+        def my_fake_task(foo):
+            pass
+
+        params = [Parameter(str(i)) for i in range(5)]
+
+        def make_flow():
+            with Flow("example-flow") as flow:
+                for param in params:
+                    my_fake_task(param)
+            return flow
+
+        flows = [make_flow() for _ in range(10)]
+
+        hashes = {flow.serialized_hash() for flow in flows}
+        assert len(hashes) == 1
 
     def test_is_different_with_modified_flow_name(self):
         f1 = Flow("foo")

--- a/tests/serialization/test_environments.py
+++ b/tests/serialization/test_environments.py
@@ -33,12 +33,12 @@ def test_serialize_base_environment():
 
 
 def test_serialize_base_environment_with_labels():
-    env = environments.Environment(labels=["foo", "bar"])
+    env = environments.Environment(labels=["b", "c", "a"])
 
     serialized = BaseEnvironmentSchema().dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert set(serialized["labels"]) == set(["foo", "bar"])
+    assert serialized["labels"] == ["a", "b", "c"]
 
 
 def test_serialize_dask_environment():
@@ -84,7 +84,7 @@ def test_serialize_dask_env_with_custom_specs():
 
 
 def test_serialize_dask_environment_with_labels():
-    env = environments.DaskKubernetesEnvironment(labels=["a", "b", "c"])
+    env = environments.DaskKubernetesEnvironment(labels=["b", "c", "a"])
 
     schema = DaskKubernetesEnvironmentSchema()
     serialized = schema.dump(env)
@@ -93,14 +93,15 @@ def test_serialize_dask_environment_with_labels():
     assert serialized["docker_secret"] is None
     assert serialized["min_workers"] == 1
     assert serialized["max_workers"] == 2
-    assert set(serialized["labels"]) == set(["a", "b", "c"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
     assert new.private_registry is False
     assert new.docker_secret is None
     assert new.min_workers == 1
     assert new.max_workers == 2
-    assert new.labels == set(["a", "b", "c"])
+    assert new.labels == {"a", "b", "c"}
 
 
 def test_serialize_dask_environment_with_customized_workers():
@@ -161,16 +162,17 @@ def test_serialize_fargate_task_env_with_kwargs():
 
 
 def test_serialize_fargate_task_environment_with_labels():
-    env = environments.FargateTaskEnvironment(labels=["a", "b", "c"])
+    env = environments.FargateTaskEnvironment(labels=["b", "c", "a"])
 
     schema = FargateTaskEnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert set(serialized["labels"]) == set(["a", "b", "c"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
-    assert new.labels == set(["a", "b", "c"])
+    assert new.labels == {"a", "b", "c"}
 
 
 def test_serialize_k8s_job_environment(k8s_job_spec_content):
@@ -218,17 +220,18 @@ def test_serialize_k8s_job_environment_with_labels(k8s_job_spec_content):
             file.write(k8s_job_spec_content)
 
         env = environments.KubernetesJobEnvironment(
-            job_spec_file=os.path.join(directory, "job.yaml"), labels=["a", "b", "c"]
+            job_spec_file=os.path.join(directory, "job.yaml"), labels=["b", "c", "a"]
         )
 
         schema = KubernetesJobEnvironmentSchema()
         serialized = schema.dump(env)
         assert serialized
         assert serialized["__version__"] == prefect.__version__
-        assert set(serialized["labels"]) == set(["a", "b", "c"])
+        # labels should be sorted in the serialized obj
+        assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
-    assert new.labels == set(["a", "b", "c"])
+    assert new.labels == {"a", "b", "c"}
 
 
 def test_serialize_remote_environment():
@@ -250,7 +253,7 @@ def test_serialize_remote_environment():
 
 
 def test_serialize_remote_environment_with_labels():
-    env = environments.RemoteEnvironment(labels=["bob", "alice"])
+    env = environments.RemoteEnvironment(labels=["b", "c", "a"])
 
     schema = RemoteEnvironmentSchema()
     serialized = schema.dump(env)
@@ -258,12 +261,13 @@ def test_serialize_remote_environment_with_labels():
     assert serialized["__version__"] == prefect.__version__
     assert serialized["executor"] == prefect.config.engine.executor.default_class
     assert serialized["executor_kwargs"] == {}
-    assert set(serialized["labels"]) == set(["bob", "alice"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
     assert new.executor == prefect.config.engine.executor.default_class
     assert new.executor_kwargs == {}
-    assert new.labels == set(["bob", "alice"])
+    assert new.labels == {"b", "c", "a"}
 
 
 def test_serialize_remote_dask_environment():
@@ -284,7 +288,7 @@ def test_serialize_remote_dask_environment():
 
 def test_serialize_remote_dask_environment_with_labels():
     env = environments.RemoteDaskEnvironment(
-        address="test", labels=["bob", "alice"], executor_kwargs={"not": "present"}
+        address="test", labels=["b", "c", "a"], executor_kwargs={"not": "present"}
     )
 
     schema = RemoteDaskEnvironmentSchema()
@@ -292,24 +296,26 @@ def test_serialize_remote_dask_environment_with_labels():
     assert serialized
     assert serialized["__version__"] == prefect.__version__
     assert serialized["address"] == "test"
-    assert set(serialized["labels"]) == set(["bob", "alice"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
     assert new.address == "test"
-    assert new.labels == set(["bob", "alice"])
+    assert new.labels == {"b", "c", "a"}
 
 
 def test_serialize_local_environment_with_labels():
-    env = environments.LocalEnvironment(labels=["bob", "alice"])
+    env = environments.LocalEnvironment(labels=["b", "c", "a"])
 
     schema = RemoteEnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized
     assert serialized["__version__"] == prefect.__version__
-    assert set(serialized["labels"]) == set(["bob", "alice"])
+    # labels should be sorted in the serialized obj
+    assert serialized["labels"] == ["a", "b", "c"]
 
     new = schema.load(serialized)
-    assert new.labels == set(["bob", "alice"])
+    assert new.labels == {"b", "c", "a"}
 
 
 def test_deserialize_old_env_payload():
@@ -330,7 +336,7 @@ def test_serialize_custom_environment():
     class MyEnv(environments.Environment):
         def __init__(self, x=5):
             self.x = 5
-            super().__init__(labels=["foo", "bar"], metadata={"test": "here"})
+            super().__init__(labels=["b", "c", "a"], metadata={"test": "here"})
 
         def custom_method(self):
             pass
@@ -339,10 +345,10 @@ def test_serialize_custom_environment():
     schema = EnvironmentSchema()
     serialized = schema.dump(env)
     assert serialized["type"] == "CustomEnvironment"
-    assert set(serialized["labels"]) == set(["foo", "bar"])
+    assert serialized["labels"] == ["a", "b", "c"]
     assert serialized["metadata"] == {"test": "here"}
 
     obj = schema.load(serialized)
     assert isinstance(obj, environments.Environment)
-    assert obj.labels == set(["foo", "bar"])
+    assert obj.labels == {"a", "b", "c"}
     assert obj.metadata == {"test": "here"}

--- a/tests/serialization/test_run_configs.py
+++ b/tests/serialization/test_run_configs.py
@@ -1,7 +1,15 @@
 import pytest
 
 from prefect.run_configs import KubernetesRun, LocalRun, DockerRun, ECSRun
-from prefect.serialization.run_config import RunConfigSchema
+from prefect.serialization.run_config import RunConfigSchema, RunConfigSchemaBase
+
+
+def test_serialized_run_config_sorts_labels():
+    assert RunConfigSchemaBase().dump({"labels": ["b", "c", "a"]})["labels"] == [
+        "a",
+        "b",
+        "c",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/serialization/test_tasks.py
+++ b/tests/serialization/test_tasks.py
@@ -25,6 +25,10 @@ def test_serialize_task():
     assert isinstance(TaskSchema().dump(Task()), dict)
 
 
+def test_serialize_task_sorts_tags():
+    assert TaskSchema().dump(Task(tags=["b", "a", "c"]))["tags"] == ["a", "b", "c"]
+
+
 def test_deserialize_task():
     task = Task(
         name="hi",
@@ -103,6 +107,14 @@ def test_serialize_parameter():
     ps = ParameterSchema().dump(p)
     assert ps["default"] == None
     assert ps["required"] is True
+
+
+def test_serialize_parameter_sorts_tags():
+    assert TaskSchema().dump(Parameter(name="p", tags=["b", "a", "c"]))["tags"] == [
+        "a",
+        "b",
+        "c",
+    ]
 
 
 def test_deserialize_parameter():

--- a/tests/utilities/test_serialization.py
+++ b/tests/utilities/test_serialization.py
@@ -18,6 +18,7 @@ from prefect.utilities.serialization import (
     ObjectSchema,
     OneOfSchema,
     StatefulFunctionReference,
+    SortedList,
 )
 
 json_test_values = [
@@ -54,6 +55,14 @@ class TestNestedField:
 
     def test_nested_respects_missing(self):
         assert self.Schema().dump({"child key": False}) == {}
+
+
+class TestSortedList:
+    class Schema(marshmallow.Schema):
+        lst = SortedList(marshmallow.fields.String())
+
+    def test_sorted_list_sorts_strings(self):
+        assert self.Schema().dump({"lst": ["c", "b", "a"]}) == {"lst": ["a", "b", "c"]}
 
 
 class TestJSONCompatibleField:


### PR DESCRIPTION
* Fix `flow.serialized_hash()` determinism with task order

* Serialize task, edges, etc. in deterministic order

* Fix type errors

* Add changes/

* Move implementation to `FlowSchema` file

* Update changes/

* Remove unnecessary string format

Co-authored-by: Jim Crist-Harif <jcrist@users.noreply.github.com>

* Add implementation of `SortedList` field

* Use `SortedList` for label schemas

For determinism in flow serialization

* Sort task tags when serialized

* Remove unused __init__

Co-authored-by: Jim Crist-Harif <jcrist@users.noreply.github.com>

* Add coverage for serialized order

* Remove unused import

* Add support for non-flow types and "missing" fields

Co-authored-by: Jim Crist-Harif <jcrist@users.noreply.github.com>

<!-- Thanks for contributing to Prefect Core! 🎉-->

## Summary
<!-- A sentence summarizing the PR -->




## Changes
<!-- What does this PR change? -->




## Importance
<!-- Why is this PR important? -->




## Checklist
<!-- PRs will not be reviewed unless these boxes are checked -->

This PR:

- [ ] adds new tests (if appropriate)
- [ ] adds a change file in the `changes/` directory (if appropriate)
- [ ] updates docstrings for any new functions or function arguments, including `docs/outline.toml` for API reference docs (if appropriate)